### PR TITLE
Cache key fixes

### DIFF
--- a/lib/cache-keys.bash
+++ b/lib/cache-keys.bash
@@ -18,18 +18,23 @@ function find_cache() {
     exit 2
   fi
 
+  env_vars=()
+  env_vars+=("-e" "AWS_VAULT=${AWS_VAULT:-}")
+  env_vars+=("-e" "AWS_REGION=${AWS_REGION:-}")
+  env_vars+=("-e" "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}")
+  env_vars+=("-e" "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}")
+  env_vars+=("-e" "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}")
+  env_vars+=("-e" "AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN:-}")
+  env_vars+=("-e" "AWS_SESSION_EXPIRATION=${AWS_SESSION_EXPIRATION:-}")
+  if [[ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}" ]]; then
+    env_vars+=("-e" "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}")
+  fi
+
   docker \
     --log-level "error" \
     run \
     --rm \
-    -e AWS_VAULT="${AWS_VAULT:-}" \
-    -e AWS_REGION="${AWS_REGION:-}" \
-    -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}" \
-    -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}" \
-    -e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}" \
-    -e AWS_SECURITY_TOKEN="${AWS_SECURITY_TOKEN:-}" \
-    -e AWS_SESSION_EXPIRATION="${AWS_SESSION_EXPIRATION:-}" \
-    -e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI="${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" \
+    "${env_vars[@]}" \
     docker-cache-buildkite-plugin:find-cache \
     ruby -I . cli.rb \
     "$bucket" "$prefix" "${keys[@]}"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -162,5 +162,6 @@ function expand_key() {
     CACHE_KEY="${BASH_REMATCH[1]}${EXPANDED_VALUE}${BASH_REMATCH[3]}"
   done
 
+  CACHE_KEY=${CACHE_KEY//\//-}
   echo "$CACHE_KEY"
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -100,6 +100,33 @@ teardown() {
   unstub aws
 }
 
+@test "Save: Sanitizes cache keys" {
+  export BUILDKITE_JOB_ID=1111
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_ORGANIZATION_SLUG=slug
+  export BUILDKITE_PIPELINE_SLUG=pipeline
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_NAME=bundler-cache
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_S3_BUCKET=bucket
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_KEYS_0='v1-bundler-cache-{{ arch }}-scoped/branch/name-{{ checksum "tests/fixtures/lockfile" }}'
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_KEYS_1='v1-bundler-cache-{{ arch }}-scoped/branch/name'
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_VOLUMES_0=bundler-data
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_VOLUMES_1=yarn-data
+  export BUILDKITE_PLUGIN_DOCKER_CACHE_SAVE=1
+
+  stub aws \
+    "s3api head-object --bucket bucket --key slug/pipeline/v1-bundler-cache-linux-x86_64-scoped-branch-name-d958fad66a3456aa1f7b9e492063ed3de2baabb0.tar : exit 0"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_line --regexp "Saving Docker Cache: .*bundler-cache.*"
+  assert_output --partial "Using cache key: v1-bundler-cache-linux-x86_64-scoped-branch-name-d958fad66a3456aa1f7b9e492063ed3de2baabb0"
+  assert_output --partial "Skipping cache save; cache already exists"
+
+  unstub aws
+
+}
+
 @test "Save: Persists cache to S3" {
   export BUILDKITE_JOB_ID=1111
   export BUILDKITE_BUILD_NUMBER=1


### PR DESCRIPTION
- Convert `/` in cache keys to `-`
- Only add `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` if it's set in the env already. Adding it as a blank env var appears to break `aws` when run locally.