### PR TITLE
Cache keys: Use first matching key

### DIFF
--- a/ruby/find_cache.rb
+++ b/ruby/find_cache.rb
@@ -36,6 +36,8 @@ class FindCache
           resolved_time = object.last_modified
         end
       end
+
+      break if resolved_key != nil
     end
 
     if resolved_key.nil?

--- a/ruby/spec/find_cache_spec.rb
+++ b/ruby/spec/find_cache_spec.rb
@@ -1,7 +1,7 @@
 require 'find_cache'
 
 RSpec.describe FindCache do
-  let(:bucket) { 'outstand-buildkite-cache' }
+  let(:bucket) { 'outstand-buildkite-data' }
   let(:prefix) { 'outstand/docker-cache-buildkite-plugin/fixtures' }
 
   it 'fetches the most specific cache key' do
@@ -47,5 +47,21 @@ RSpec.describe FindCache do
 
     expect(result).to be_success
     expect(result.resolved_key).to be_nil
+  end
+
+  it 'respects key order' do
+    keys = [
+      'v1-bundler-cache-linux-x86_64-branch-name-',
+      'v1-bundler-cache-linux-x86_64-'
+    ]
+
+    result = FindCache.call(
+      keys: keys,
+      bucket: bucket,
+      prefix: prefix
+    )
+
+    expect(result).to be_success
+    expect(result.resolved_key).to eq 'v1-bundler-cache-linux-x86_64-branch-name-deadbeef'
   end
 end

--- a/tests/cache-keys.bats
+++ b/tests/cache-keys.bats
@@ -5,7 +5,7 @@ load '../lib/shared'
 load '../lib/cache-keys'
 
 @test "Cache keys: Find key based on prefix" {
-  bucket=outstand-buildkite-cache
+  bucket=outstand-buildkite-data
   prefix=outstand/docker-cache-buildkite-plugin/fixtures
   run find_cache "$bucket" "$prefix" "v1-bundler-cache-"
 
@@ -14,7 +14,7 @@ load '../lib/cache-keys'
 }
 
 @test "Cache keys: exit 1 when no key is found" {
-  bucket=outstand-buildkite-cache
+  bucket=outstand-buildkite-data
   prefix=outstand/docker-cache-buildkite-plugin/fixtures
 
   run find_cache "$bucket" "$prefix" "do-not-find-me"
@@ -24,7 +24,7 @@ load '../lib/cache-keys'
 }
 
 @test "Cache keys: Reports on failure" {
-  bucket=outstand-buildkite-cache
+  bucket=outstand-buildkite-data
   prefix=outstand/docker-cache-buildkite-plugin/fixtures
 
   stub docker \


### PR DESCRIPTION
Instead of finding the longest match for _all_ prefixes. Find the longest match for the most specific prefix.

This means that if we get a hit for the first key, we don't continue searching any less specific keys which may match longer and incorrect things.