### PR TITLE
Preserve dots in the cache key name

### DIFF
--- a/ruby/find_cache.rb
+++ b/ruby/find_cache.rb
@@ -44,7 +44,9 @@ class FindCache
       context.resolved_key = nil
     else
       # Find last path segment and remove file extension
-      context.resolved_key = resolved_key.split('/').last.split('.').first
+      resolved_key = resolved_key.split('/').last
+      extension = resolved_key.split('.').last
+      context.resolved_key = resolved_key.delete_suffix(".#{extension}")
     end
   end
 

--- a/ruby/spec/find_cache_spec.rb
+++ b/ruby/spec/find_cache_spec.rb
@@ -64,4 +64,20 @@ RSpec.describe FindCache do
     expect(result).to be_success
     expect(result.resolved_key).to eq 'v1-bundler-cache-linux-x86_64-branch-name-deadbeef'
   end
+
+  it 'preserves dots in the key name' do
+    keys = [
+      'v1-bundler-cache-linux-x86_64-longer-branch-name-1.2.3'
+    ]
+
+    result = FindCache.call(
+      keys: keys,
+      bucket: bucket,
+      prefix: prefix
+    )
+
+    expect(result).to be_success
+    expect(result.resolved_key).to eq 'v1-bundler-cache-linux-x86_64-longer-branch-name-1.2.3'
+
+  end
 end


### PR DESCRIPTION
I discovered that cache keys with dots in their names confused the code I wrote to remove the file extension from the end of the S3 match. Now it's careful to only remove the final dot and string.